### PR TITLE
Changed hint_domain string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="status_sent">Sent!</string>
     <string name="status_sent_long">Reply sent successfully.</string>
 
-    <string name="hint_domain">Which instance?</string>
+    <string name="hint_domain">Which ActivityPub instance?</string>
     <string name="hint_compose">What\'s happening?</string>
     <string name="hint_content_warning">Content warning</string>
     <string name="hint_display_name">Display name</string>


### PR DESCRIPTION
On the hint_domain string, I changed from "Which instance?" to "Which ActivityPub instance?", for new people to understand that *any* ActivePub instance works, from pleroma to mastodon.